### PR TITLE
1 initialize terraform and verify gcp access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,18 @@
+#Terraform version and google requirements
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+        source = "hashicorp/google"
+        version = "~> 5.0"
+    }
+  }
+}
+
+#GCP provider, reuse variables from variables.tf
+provider "google" {
+  project = var.project_id
+  region = var.region
+  zone = var.zone
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,1 @@
+#Initialitzed empty file

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,24 @@
+# GCP Project config
+variable "project_id" {
+  description = "GCP project ID"
+  type = string
+}
+
+# Region and Zone config 
+variable "region" {
+  description = "GCP region for resources"
+  type = string
+  default = "europe-north1" #Closest to Norway
+}
+
+variable "zone" {
+  description = "GCP zone for compute resources"
+  type = string
+  default = "europe-north1-a" #a in additon for zone (datacenter)
+}
+
+variable "student_name" {
+  description = "Student name for labes"
+  type = string 
+  default = "sondre_nodenes"
+}


### PR DESCRIPTION
## What
Initialize Terraform project with GCP provider configuration

## Changes
- Add variables.tf with project, region, zone configuration
- Add main.tf with Terraform and Google provider setup
- Initialized outputs.tf 
- Add .gitignore for Terraform files
- Add terraform.tfvars with project ID (not committed)

## Testing
- [x] terraform init successful
- [x] terraform plan shows no changes
- [x]  GCP authentication verified