### PR TITLE
Added firewall rules fr HTTP and SSH

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,3 +51,32 @@ resource "google_compute_instance" "vm" {
     }
 }
 
+#Firewall rule to alow HTTP traffic from the whole internet (source_ranges) to intern-assignments
+resource "google_compute_firewall" "allow_htp" {
+  name = "allow-http-intern-assignment"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports = ["80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["intern-assignment"]
+}
+
+#Firewall rule to allow SSH from allowed groups/users
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name = "allow-iap-ssh-intern-assignment"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports = ["22"]
+
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags = ["intern-assignment"]
+}
+


### PR DESCRIPTION
### What
Configured firewall rules to allow HTTP traffic and secure SSH access via IAP.

### Changes
- Added firewall rule to allow HTTP (port 80) from internet
- Added firewall rule to allow SSH (port 22) from IAP IP range only
- Both rules target VMs with tag `intern-assignment`

### Testing
- [x] Verified firewall rules with `gcloud compute firewall-rules list`
- [x] Confirmed HTTP port 80 is open (connection refused = expected, no webserver yet)
- [x] Confirmed direct SSH is blocked