### PR TITLE
9 configure iap ssh access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,3 +82,9 @@ resource "google_compute_firewall" "allow_iap_ssh" {
   target_tags = ["intern-assignment"]
 }
 
+resource "google_project_iam_member" "iap_tunnel_user" {
+  project = var.project_id
+  role = "roles/iap.tunnelResourceAccessor" #Assign member this role
+  member = "user:sondrenf@gmail.com"
+}
+

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,9 @@ resource "google_compute_instance" "vm" {
     machine_type = var.machine_type
     zone = var.zone
 
+    allow_stopping_for_update = true
+
+
     # Tag for firewall rules 
     tags = ["intern-assignment"]
 

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,11 @@ resource "google_compute_instance" "vm" {
 
     metadata_startup_script = file("${path.module}/startup-script.sh")
 
+    #service account for VM
+    service_account {
+      scopes = ["cloud-platform"]
+    }
+
     boot_disk{
         initialize_params{
             image = data.google_compute_image.debian.self_link

--- a/main.tf
+++ b/main.tf
@@ -90,9 +90,12 @@ resource "google_compute_firewall" "allow_iap_ssh" {
   target_tags = ["intern-assignment"]
 }
 
+/*
 resource "google_project_iam_member" "iap_tunnel_user" {
   project = var.project_id
   role = "roles/iap.tunnelResourceAccessor" #Assign member this role
   member = "user:sondrenf@gmail.com"
 }
+
+*/
 


### PR DESCRIPTION
### What
  Configured IAP SSH access for secure VM connectivity without exposing SSH to the internet.
### Changes
- Added `allow_stopping_for_update = true` to enable VM updates without recreation
- Commented out IAM member configuration (requires project-level permissions)
### Testing
- [x] terraform plan 
- [x] terraform apply
- [x] gcloud compute ssh --tunnel-through-iap
- [x] Confirmed no direct SSH access from internet 