### PR TITLE
Added DNS A record for VM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,3 +99,12 @@ resource "google_project_iam_member" "iap_tunnel_user" {
 
 */
 
+# DNS A record pointing to VM's external IP
+resource "google_dns_record_set" "vm_dns" {
+  name         = "vm.sandbox4.vcops.tech."
+  type         = "A"
+  ttl          = 300
+  managed_zone = "sandbox4-vcops-tech"
+  
+  rrdatas = [google_compute_instance.vm.network_interface[0].access_config[0].nat_ip]
+}


### PR DESCRIPTION
### What
Created DNS A record pointing to VM's external IP for easy acces via friendly domain name.
### Changes
- Added google_dns_record_set in main
- DNS record: vm.sandbox4.vcops.tech
- Points to VM's external IP using terraform
- TTL: 300 seconds
### Testing
- [x] terraform plan 
- [x] terraform apply
- [x] nslookup vm.sandbox4.vcops.tech
- [x] http://vm.sandbox4.vcops.tech