### PR TITLE
10 readme documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files
+*.tfvars
+*.tfvars.json
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The assignment demonstrates:
 
 ## Connecting via SSH
 
-SSH access is configured to work exclusively through Identity-Aware Proxy (IAP).
+SSH access is configured to work **exclusively through Identity-Aware Proxy (IAP)**.
 
 
 ## Project Structure
@@ -33,6 +33,17 @@ SSH access is configured to work exclusively through Identity-Aware Proxy (IAP).
 - User must have IAM role `roles/iap.tunnelResourceAccessor` (managed by project administrators)
 - Firewall allows SSH only from IAP IP range (35.235.240.0/20)
 
+## Deploy:
+```bash 
+terraform init
+terraform plan
+terraform apply
+```
+
+## Access info
+```bash
+terraform output
+```
 
 ### Connect to VM
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,5 +12,24 @@ The assignment demonstrates:
 - Firewall configuration following security best practices
 - Automated web server setup using startup scripts
 
+## Connecting via SSH
+
+SSH access is configured to work exclusively through Identity-Aware Proxy (IAP).
+
+**Requirements:**
+- IAP API must be enabled in the GCP project
+- User must have IAM role `roles/iap.tunnelResourceAccessor` (managed by project administrators)
+- Firewall allows SSH only from IAP IP range (35.235.240.0/20)
+
+
+### Connect to VM
+```bash
+gcloud compute ssh px-intern-vm \
+  --zone=europe-north1-a \
+  --tunnel-through-iap \
+  --project=optimal-shard-332612
+
+
+
 ## Project Structure
 - In progress

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This repository contains an **IaC solution** for deploying a secure web server o
 - HTTPS: https://vm.sandbox4.vcops.tech
 - DNS: http://vm.sandbox4.vcops.tech
 
-
 ## Project Structure
 ```bash
 .

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 **Author:** Sondre Nodenes-Fimland
 
 ## Overview
-
-This repository contains an Infrastructure as Code (IaC) solution for deploying a secure web server on Google Cloud Platform using Terraform.
+This repository contains an **IaC solution** for deploying a secure web server on **Google Cloud Platform (GCP)** using **Terraform**.
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,20 @@ The assignment demonstrates:
 
 SSH access is configured to work exclusively through Identity-Aware Proxy (IAP).
 
-**Requirements:**
+
+## Project Structure
+```bash
+.
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── terraform.tfvars
+├── startup-script.sh
+└── README.md
+
+```
+
+## Requirements
 - IAP API must be enabled in the GCP project
 - User must have IAM role `roles/iap.tunnelResourceAccessor` (managed by project administrators)
 - Firewall allows SSH only from IAP IP range (35.235.240.0/20)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ SSH access is configured to work exclusively through Identity-Aware Proxy (IAP).
 ├── terraform.tfvars
 ├── startup-script.sh
 └── README.md
-
 ```
 
 ## Requirements
@@ -41,8 +40,4 @@ gcloud compute ssh px-intern-vm \
   --zone=europe-north1-a \
   --tunnel-through-iap \
   --project=optimal-shard-332612
-
-
-
-## Project Structure
-- In progress
+```

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 ## Overview
 This repository contains an **IaC solution** for deploying a secure web server on **Google Cloud Platform (GCP)** using **Terraform**.
 
-
-
 **Implemented**:
 - VM instance (e2-micro, Debian 12)
 - SSH access via Identity-Aware Proxy (IAP)
@@ -15,9 +13,11 @@ This repository contains an **IaC solution** for deploying a secure web server o
 - DNS A record
 - Let's Encrypt TLS certificate
 
-## Web Acccess
+
+## Web Access
 - HTTPS: https://vm.sandbox4.vcops.tech
 - DNS: http://vm.sandbox4.vcops.tech
+
 
 ## Project Structure
 ```bash
@@ -36,7 +36,7 @@ This repository contains an **IaC solution** for deploying a secure web server o
 - IAP API must be enabled in the GCP project
 - User must have IAM role `roles/iap.tunnelResourceAccessor` (managed by project administrators)
 
-## Deploy:
+## Deploy
 ```bash 
 terraform init
 terraform plan
@@ -49,6 +49,7 @@ terraform output
 ```
 
 ### Connect to VM (SSH via IAP)
+---
 ```bash
 gcloud compute ssh px-intern-vm \
   --zone=europe-north1-a \
@@ -57,3 +58,5 @@ gcloud compute ssh px-intern-vm \
 ```
 
 
+***Contact***
+sondrenf@gmail.com

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This repository contains an Infrastructure as Code (IaC) solution for deploying a secure web server on Google Cloud Platform using Terraform.
 
+
+
 **Implemented**:
 - VM instance (e2-micro, Debian 12)
 - SSH access via Identity-Aware Proxy (IAP)
@@ -14,6 +16,9 @@ This repository contains an Infrastructure as Code (IaC) solution for deploying 
 - DNS A record
 - Let's Encrypt TLS certificate
 
+## Web Acccess
+- HTTPS: https://vm.sandbox4.vcops.tech
+- DNS: http://vm.sandbox4.vcops.tech
 
 ## Project Structure
 ```bash
@@ -27,9 +32,10 @@ This repository contains an Infrastructure as Code (IaC) solution for deploying 
 ```
 
 ## Requirements
+- Google Cloud SDK authenticated
+- Terraform >= 1.0
 - IAP API must be enabled in the GCP project
 - User must have IAM role `roles/iap.tunnelResourceAccessor` (managed by project administrators)
-- Firewall allows SSH only from IAP IP range (35.235.240.0/20)
 
 ## Deploy:
 ```bash 
@@ -43,10 +49,12 @@ terraform apply
 terraform output
 ```
 
-### Connect to VM
+### Connect to VM (SSH via IAP)
 ```bash
 gcloud compute ssh px-intern-vm \
   --zone=europe-north1-a \
   --tunnel-through-iap \
   --project=optimal-shard-332612
 ```
+
+

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@
 
 This repository contains an Infrastructure as Code (IaC) solution for deploying a secure web server on Google Cloud Platform using Terraform.
 
-The assignment demonstrates:
-- VM instance deployment on GCP Compute Engine
-- Secure SSH access via Identity-Aware Proxy (IAP)
-- Firewall configuration following security best practices
-- Automated web server setup using startup scripts
-
-## Connecting via SSH
-
-SSH access is configured to work **exclusively through Identity-Aware Proxy (IAP)**.
+**Implemented**:
+- VM instance (e2-micro, Debian 12)
+- SSH access via Identity-Aware Proxy (IAP)
+- HTTP/HTTPS firewall rules
+- Automated Nginx web server
+- DNS A record
+- Let's Encrypt TLS certificate
 
 
 ## Project Structure


### PR DESCRIPTION
### What
Added README documentation covering project setup, deployment and access instructions.
### Changes
 - Added project overview with implemented features
 - Documented prerequisites (GCP auth, Terraform, IAP API, IAM roles)
 - Added deployment commands (init/plan/apply)
 - Included complete gcloud SSH command for IAP access
 - Added project structure visualization
 - Listed web access URLs (HTTP/HTTPS)
 - Included .gitignore and terraform.lock.hcl
### Testing
- [x] Read README in preview mode and on github
